### PR TITLE
fix: serialize each route view path once

### DIFF
--- a/.changeset/clean-page-route-paths.md
+++ b/.changeset/clean-page-route-paths.md
@@ -1,0 +1,5 @@
+---
+"filesystem-routing": patch
+---
+
+Serialize flat and nested route paths separately so generated page routes do not overwrite manifest paths from shared fields.

--- a/src/vite/index.ts
+++ b/src/vite/index.ts
@@ -334,11 +334,12 @@ export function fileRoutes(options: FileRoutesOptions = {}): PluginOption[] {
             .replaceAll('"_$(', "(")
             .replaceAll(')$_"', ")");
 
-        // Entries are emitted once and both views reference them, so the
-        // nested view costs its own paths and nothing else.
-        const bindings = routes.map(
-          (route, index) => `const route${index} = ${serializeEntry(route)};`
-        );
+        // Emit the fields that both views share once. Each view adds its own
+        // path, so the nested view does not overwrite the flat manifest path.
+        const bindings = routes.map((route, index) => {
+          const { path: _path, ...fields } = route;
+          return `const route${index} = ${serializeEntry(fields)};`;
+        });
 
         const tree = buildRouteTree(
           routes
@@ -361,7 +362,9 @@ export function fileRoutes(options: FileRoutesOptions = {}): PluginOption[] {
 
         return `${js.getImportStatements()}
 ${bindings.join("\n")}
-const routes = [${routes.map((_, index) => `route${index}`).join(", ")}];
+const routes = [${routes
+          .map((route, index) => `{ path: ${JSON.stringify(route.path)}, ...route${index} }`)
+          .join(", ")}];
 export default routes;
 export const pageRoutes = ${serializeTree(tree)};
 `;

--- a/test/vite.spec.ts
+++ b/test/vite.spec.ts
@@ -62,7 +62,7 @@ describe("fileRoutes vite plugin", () => {
     expect(code).toMatch(
       /import { route as routeData0 } from '[^']*\[id\]\.tsx\?pick=route&lang\.tsx';/
     );
-    expect(code).toContain(`"path":"/blog/:id"`);
+    expect(code).toContain(`path: "/blog/:id"`);
     expect(code).toContain(`'route': routeData0`);
   });
 
@@ -76,13 +76,59 @@ describe("fileRoutes vite plugin", () => {
     const code = await loadVirtualModule(root);
 
     // the layout keeps its group segment in the flat view...
-    expect(code).toContain(`"path":"/(app)"`);
+    expect(code).toContain(`path: "/(app)"`);
     // ...and loses it in the nested one, where the child is relative to it
     expect(code).toMatch(
       /export const pageRoutes = \[\{ \.\.\.route\d, id: "\/\(app\)", path: "\/", children: \[\{ \.\.\.route\d, id: "\/dashboard", path: "\/dashboard" \}\] \}\]/
     );
     // entries are referenced, not copied, so refs are emitted exactly once
     expect(code.match(/pick=default&pick=\$css&lang\.tsx'\)/g)?.length).toBe(2);
+  });
+
+  it("assigns each route view its own path once", async () => {
+    const root = createRouteTree({});
+    const router = {
+      getRoutes: async () => [
+        { path: "/(app)", page: true, metadata: { level: 0 } },
+        { path: "/(app)/dashboard", page: true, metadata: { level: 1 } },
+        { path: "/(app)/dashboard/settings", page: true, metadata: { level: 2 } }
+      ]
+    } as unknown as PageFileSystemRouter;
+
+    const code = await loadWith(createPlugin(root, { router }), root);
+    const sharedEntries = [...code.matchAll(/^const route\d+ = (\{.*\});$/gm)].map(match =>
+      JSON.parse(match[1])
+    );
+
+    // A shared entry must not contain either view's path. Otherwise the
+    // pageRoutes spread assigns the flat path before it assigns the tree path.
+    expect(sharedEntries).toHaveLength(3);
+    expect(sharedEntries.every(entry => !Object.hasOwn(entry, "path"))).toBe(true);
+
+    const module = await import(
+      `data:text/javascript;base64,${Buffer.from(code).toString("base64")}`
+    );
+
+    expect(module.default.map((route: { path: string }) => route.path)).toEqual([
+      "/(app)",
+      "/(app)/dashboard",
+      "/(app)/dashboard/settings"
+    ]);
+    expect(module.pageRoutes).toMatchObject([
+      {
+        id: "/(app)",
+        path: "/",
+        children: [
+          {
+            id: "/dashboard",
+            path: "/dashboard",
+            children: [{ id: "/settings", path: "/settings" }]
+          }
+        ]
+      }
+    ]);
+    // Both views still share the non-path fields and their nested values.
+    expect(module.default[0].metadata).toBe(module.pageRoutes[0].metadata);
   });
 
   it("resolves only the virtual module id", async () => {
@@ -229,7 +275,7 @@ describe("fileRoutes vite plugin", () => {
       expect(code).not.toContain("/api/users");
       // the page half of a page+handler module stays routable
       expect(code).toMatch(/import\('[^']*users\.tsx\?pick=default&pick=\$css&lang\.tsx'\)/);
-      expect(code).toContain('"path":"/users"');
+      expect(code).toContain('path: "/users"');
     });
 
     it("splits by consumer, not by name, when the environment declares one", async () => {


### PR DESCRIPTION
## Summary

- Serialize fields shared by the flat and nested views without `path`.
- Add the original manifest path once when the flat view is built.
- Keep the group-stripped, parent-relative path once in each `pageRoutes` object.
- Add a patch changeset and regression coverage for a three-level group route.

## Root cause

The Vite adapter serialized each complete flat manifest entry into a shared binding. `serializeTree` spread that binding into a page route and then added the adjusted tree path. Thus, the spread first assigned the original flat path, and the explicit `path` field replaced it.

This shape is valid JavaScript. A minimal Vite 8 build, TypeScript, and esbuild accept it. The problem is an unwanted assignment in generated source, not a duplicate-key syntax error.

The shared binding now contains only fields common to both views. The flat route adds its original path, while the nested page route adds its adjusted path. This keeps route-group removal and parent-relative nesting. It also keeps IDs, children, module refs, and other nested values. The two views still share these non-path values.

## Tests

The regression test inspects the generated shared bindings and evaluates the generated module. It covers:

- original paths in the flat manifest;
- a pathless group layout;
- group removal in `pageRoutes`;
- parent-relative paths through three levels;
- IDs and children;
- shared non-path data.

The test fails on base commit `4ff503f` and passes with this change.

Validation with Node 24.15.0 and pnpm 11.1.1:

- `pnpm install --frozen-lockfile` — passed
- `pnpm vitest run test/vite.spec.ts -t 'assigns each route view its own path once'` — passed
- `pnpm test` — passed, 104 tests
- `pnpm build` — passed
- `pnpm typecheck:dist` — passed
- `npm pack --dry-run` — passed
- `pnpm prettier --check src/vite/index.ts test/vite.spec.ts .changeset/clean-page-route-paths.md` — passed
- packed package with Vite 8.2.2 — lazy and eager production builds passed

Fixes #10
